### PR TITLE
Added forgot password pages, no password/email error logic yet

### DIFF
--- a/src/components/Landing/Forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/Landing/Forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,9 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Card } from '@mui/material';
+import { Card, TextField, Stack, Typography, CircularProgress } from '@mui/material';
 
-const ForgotPassword = () => {
-  return <Card className='w-[600px] h-[400px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl drop-shadow-2xl' />;
+import { NavLink } from 'react-router-dom';
+import { routes } from '@/constants/routes';
+import { LoadingButton } from '@mui/lab';
+
+const ForgotPasswordForm = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [email, setEmail] = useState<string>('');
+  const [emailError, setEmailError] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSendCode = () => {
+    console.log('code sent');
+    navigate(routes.authentication.newPassword);
+  };
+
+  const onEmailChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    if (emailError) {
+      setEmailError(false);
+    }
+    setEmail(event.target.value); //updates input field text
+  };
+
+  return (
+    <Card className='w-[600px] h-[400px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl drop-shadow-2xl'>
+      <Stack className='my-6 mx-12' spacing={1}>
+        <Stack className='font-Inter' spacing={-1}>
+          <Typography className='text-[52px]'>Reset Password</Typography>
+          <Stack className='mx-8.3.5' direction='row' spacing={1}>
+            <Typography className='text-[16px]'>
+              Remember your Password Silly?{' '}
+              <NavLink to={routes.authentication.login} className='text-uclaBlue hover:underline underline-offset-4'>
+                Sign In
+              </NavLink>
+            </Typography>
+          </Stack>
+        </Stack>
+
+        <Stack className='my-12 mx-8' spacing={1.5}>
+          <TextField
+            label='Email'
+            value={email}
+            error={emailError}
+            onChange={onEmailChange}
+            onKeyPress={e => e.key === 'Enter' && handleSendCode}
+          />
+        </Stack>
+
+        <div className='absolute bottom-20 right-10 h-16 w-16'>
+          <LoadingButton
+            loading={isLoading}
+            onClick={handleSendCode}
+            className='bg-uclaBlue normal-case w-40 h-11 text-lg rounded-lg font-Inter float-right '
+            variant='contained'
+            loadingIndicator={<CircularProgress size={16} className='text-bgWhite' />}
+          >
+            Send Code
+          </LoadingButton>
+        </div>
+      </Stack>
+    </Card>
+  );
 };
 
-export default ForgotPassword;
+export default ForgotPasswordForm;

--- a/src/components/Landing/LandingWrapper/LandingWrapper.tsx
+++ b/src/components/Landing/LandingWrapper/LandingWrapper.tsx
@@ -3,7 +3,7 @@ import LandingImage from '@/assets/images/Landing-Image.jpg';
 
 type Props = {
   Form: () => JSX.Element;
-};
+}; //combines login form with background image(landing wrapper)
 
 const LandingWrapper = ({ Form }: Props) => {
   return (

--- a/src/components/Landing/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/components/Landing/NewPasswordForm/NewPasswordForm.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { NavLink } from 'react-router-dom';
+import { routes } from '@/constants/routes';
+import { LoadingButton } from '@mui/lab';
+
+import { Card, TextField, OutlinedInput, Stack, Typography, CircularProgress, FormControl, InputLabel } from '@mui/material';
+
+const NewPasswordForm = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [emailcode, setEmailCode] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [reEnterPassword, setReEnterPassword] = useState<string>('');
+  const [codeError, setCodeError] = useState(false);
+  const [passwordError, setPasswordError] = useState(false);
+  const [reEnterPasswordError, setReEnterPasswordError] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSignIn = () => {
+    console.log('sign in');
+    navigate(routes.authentication.login);
+  };
+
+  const onCodeChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    if (codeError) {
+      setCodeError(false);
+      if (password.trim().length != 0) {
+        setPasswordError(false);
+      }
+    }
+    setEmailCode(event.target.value);
+  };
+
+  const onPasswordChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    if (passwordError) {
+      setPasswordError(false);
+    }
+    setPassword(event.target.value);
+  };
+
+  const onReEnterPasswordChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    if (password === reEnterPassword) {
+      setReEnterPasswordError(false);
+    } else {
+      setReEnterPasswordError(true);
+    }
+    setReEnterPassword(event.target.value);
+  };
+
+  return (
+    <Card className='w-[600px] h-[450px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-3xl drop-shadow-2xl'>
+      <Stack className='my-6 mx-12' spacing={2.5}>
+        <Stack className='font-Inter' spacing={-1}>
+          <Typography className='text-[52px]'>Reset Password</Typography>
+          <Stack className='mx-8.3.5' direction='row' spacing={1}>
+            <Typography className='text-[16px]'>
+              Remember your Password Silly?{' '}
+              <NavLink to={routes.authentication.login} className='text-uclaBlue hover:underline underline-offset-4'>
+                Log In
+              </NavLink>
+            </Typography>
+          </Stack>
+        </Stack>
+
+        <Stack className='mx-8 pt-1' spacing={2}>
+          <TextField
+            label='Email Code'
+            value={emailcode}
+            error={codeError}
+            onChange={onCodeChange}
+            onKeyDown={e => e.key === 'Enter' && handleSignIn()}
+          />
+
+          <FormControl sx={{ m: 1 }} variant='outlined'>
+            <InputLabel htmlFor='outlined-adornment-password' error={passwordError}>
+              New Password &lt; 6+ characters, 1+ special character &gt;
+            </InputLabel>
+            <OutlinedInput
+              id='outlined-adornment-password'
+              error={passwordError}
+              type={'password'}
+              value={password}
+              onChange={onPasswordChange}
+              label='New Password <6+ characters, 1 special character>'
+            />
+          </FormControl>
+
+          <FormControl sx={{ m: 1 }} variant='outlined'>
+            <InputLabel htmlFor='outlined-adornment-password' error={passwordError}>
+              Re-enter New Password
+            </InputLabel>
+            <OutlinedInput
+              id='outlined-adornment-password'
+              error={passwordError}
+              type={'password'}
+              value={reEnterPassword}
+              onChange={onReEnterPasswordChange}
+              label='Re-enter New Password'
+            />
+          </FormControl>
+        </Stack>
+        <div className='absolute bottom-5 right-10 h-16 w-16'>
+          <LoadingButton
+            loading={isLoading}
+            onClick={handleSignIn}
+            className='bg-uclaBlue normal-case w-32 h-11 font-medium rounded-lg font-Inter float-right text-lg'
+            variant='contained'
+            loadingIndicator={<CircularProgress size={16} className='text-bgWhite' />}
+          >
+            Sign In
+          </LoadingButton>
+        </div>
+      </Stack>
+    </Card>
+  );
+};
+export default NewPasswordForm;

--- a/src/components/Routers/BaseRouter.tsx
+++ b/src/components/Routers/BaseRouter.tsx
@@ -5,6 +5,8 @@ import { routes } from '@/constants/routes';
 import Home from '@pages/Home';
 import Login from '@pages/Landing/Login';
 import SignUp from '@pages/Landing/SignUp';
+import ForgotPassword from '@/pages/Landing/ForgotPassword';
+import NewPassword from '@/pages/Landing/NewPassword';
 
 const BaseRouter = () => {
   return (
@@ -13,6 +15,8 @@ const BaseRouter = () => {
         <Route path={routes.home} element={<Home />} />
         <Route path={routes.authentication.login} element={<Login />} />
         <Route path={routes.authentication.signup} element={<SignUp />} />
+        <Route path={routes.authentication.forgotPassword} element={<ForgotPassword />} />
+        <Route path={routes.authentication.newPassword} element={<NewPassword />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -5,5 +5,6 @@ export const routes = {
     login: '/auth/login',
     signup: '/auth/signup',
     forgotPassword: '/auth/forgotPassword',
+    newPassword: '/auth/newPassword',
   },
 };

--- a/src/pages/Landing/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/Landing/ForgotPassword/ForgotPassword.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import LandingWrapper from '@/components/Landing/LandingWrapper/LandingWrapper';
+import ForgotPasswordForm from '@/components/Landing/Forms/ForgotPasswordForm/ForgotPasswordForm';
+
+const ForgotPassword = () => {
+  return <LandingWrapper Form={ForgotPasswordForm} />;
+};
+
+export default ForgotPassword;

--- a/src/pages/Landing/ForgotPassword/index.ts
+++ b/src/pages/Landing/ForgotPassword/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ForgotPassword';

--- a/src/pages/Landing/Login/Login.tsx
+++ b/src/pages/Landing/Login/Login.tsx
@@ -3,7 +3,7 @@ import LandingWrapper from '@/components/Landing/LandingWrapper/LandingWrapper';
 import LoginForm from '@/components/Landing/Forms/LoginForm/LoginForm';
 
 const Login = () => {
-  return <LandingWrapper Form={LoginForm} />;
+  return <LandingWrapper Form={LoginForm} />; //passes login form as form for landingwrapper
 };
 
 export default Login;

--- a/src/pages/Landing/NewPassword/NewPassword.tsx
+++ b/src/pages/Landing/NewPassword/NewPassword.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import LandingWrapper from '@/components/Landing/LandingWrapper/LandingWrapper';
+import NewPasswordForm from '@/components/Landing/NewPasswordForm/NewPasswordForm';
+
+const NewPassword = () => {
+  return <LandingWrapper Form={NewPasswordForm} />;
+};
+
+export default NewPassword;

--- a/src/pages/Landing/NewPassword/index.ts
+++ b/src/pages/Landing/NewPassword/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NewPassword';


### PR DESCRIPTION
Basic front-end for forgot password pages. Send code button redirects to next reset password page, and sign in button on email code page redirects to the sign in page. No logic to check password/email validity implemented yet. 